### PR TITLE
CI-Lint- und Format-Fehler beheben

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,12 +25,15 @@ Was sollte passieren?
 Was passiert stattdessen?
 
 ## Umgebung
+
 - OS: macOS / Linux / Windows
 - Python: 3.11+
 - Commit/Tag: (z. B. v0.1.0 oder SHA)
 
 ## Logs / Screenshots
+
 Füge relevante Ausgaben, Tracebacks oder Screens an.
 
 ## Zusatzinformationen
+
 Optional: weitere Hinweise.

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,8 @@
+{
+  // Zeilenlänge nicht erzwingen – README/Changelog enthalten lange Links,
+  // Tabellen und Code-URLs, bei denen harte Umbrüche die Lesbarkeit verschlechtern.
+  "MD013": false,
+
+  // Issue-Templates beginnen mit YAML-Frontmatter statt H1 – das ist gewollt.
+  "MD041": false
+}

--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ demenz_ethik_checker/
 1. Repository klonen und ins Verzeichnis wechseln.
 2. Virtuelle Umgebung anlegen (hier: `myenv`):
 
-```bash
-python3 -m venv myenv
-./myenv/bin/python -m pip install --upgrade pip
-./myenv/bin/pip install -r requirements.txt
-```
+   ```bash
+   python3 -m venv myenv
+   ./myenv/bin/python -m pip install --upgrade pip
+   ./myenv/bin/pip install -r requirements.txt
+   ```
 
 3. `.env` erstellen (aus `.env.example` kopieren) und ggf. Cloud‑Keys setzen:
 
@@ -113,17 +113,19 @@ Artefakte:
 Zusätzliche Vergleichs-Visualisierungen (aus `docs/`):
 
 - Achsenvergleich (4 Balken pro Modell: Baseline, Deterministic, Care, Autonomy)
-  
+
   ```bash
   ./myenv/bin/python src/compare.py
   ```
+
   Ergebnis: `docs/axis_comparison.png`
 
 - Entscheidungsübersicht (Matrix PEG: Ja/Nein/Unklar) und Tabellen
-  
+
   ```bash
   ./myenv/bin/python src/compare_decisions.py
   ```
+
   Ergebnisse: `docs/decision_grid.png`, `docs/decision_table.csv`, `docs/decision_table.md`
 
 ### Beispiel: Baseline‑Ergebnis (Screenshot)

--- a/judge_test.py
+++ b/judge_test.py
@@ -5,6 +5,7 @@ import os
 # .env laden
 try:
     from dotenv import load_dotenv  # type: ignore
+
     load_dotenv()
 except Exception:
     pass

--- a/run.py
+++ b/run.py
@@ -10,11 +10,17 @@ def main() -> None:
     # .env laden (lokale API-Keys, Konfigurationen)
     try:
         from dotenv import load_dotenv  # type: ignore
+
         load_dotenv()
     except Exception:
         pass
     parser = argparse.ArgumentParser(description="Demenz Ethik Checker – Läufe starten")
-    parser.add_argument("--run", required=True, choices=["baseline", "deterministic", "autonomy_bias", "care_bias"], help="Name des Runs")
+    parser.add_argument(
+        "--run",
+        required=True,
+        choices=["baseline", "deterministic", "autonomy_bias", "care_bias"],
+        help="Name des Runs",
+    )
     args = parser.parse_args()
 
     root = Path(__file__).parent

--- a/src/adapters/anthropic_claude.py
+++ b/src/adapters/anthropic_claude.py
@@ -8,7 +8,9 @@ from .base import Adapter
 class AnthropicClaudeAdapter(Adapter):
     """Anthropic-Adapter (Messages API) für "claude-sonnet-4"."""
 
-    def generate(self, system: str, user: str, temperature: float, top_p: float, max_tokens: int) -> str:
+    def generate(
+        self, system: str, user: str, temperature: float, top_p: float, max_tokens: int
+    ) -> str:
         api_key = os.getenv("ANTHROPIC_API_KEY")
         if not api_key:
             raise RuntimeError(

--- a/src/adapters/base.py
+++ b/src/adapters/base.py
@@ -6,7 +6,9 @@ from typing import Protocol
 class Adapter(Protocol):
     """Einheitliche Schnittstelle für alle Modelladapter."""
 
-    def generate(self, system: str, user: str, temperature: float, top_p: float, max_tokens: int) -> str:
+    def generate(
+        self, system: str, user: str, temperature: float, top_p: float, max_tokens: int
+    ) -> str:
         """Erzeugt einen Antworttext.
 
         Parameter:

--- a/src/adapters/local_mistral.py
+++ b/src/adapters/local_mistral.py
@@ -12,7 +12,9 @@ class LocalMistralAdapter(Adapter):
     Standardmodell: "ministral-3b-2410" (kleines, kostengünstiges Modell).
     """
 
-    def generate(self, system: str, user: str, temperature: float, top_p: float, max_tokens: int) -> str:
+    def generate(
+        self, system: str, user: str, temperature: float, top_p: float, max_tokens: int
+    ) -> str:
         api_key = os.getenv("MISTRAL_API_KEY")
         if not api_key:
             raise RuntimeError(

--- a/src/adapters/local_teuken.py
+++ b/src/adapters/local_teuken.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import Optional
 
 from .base import Adapter
 
@@ -74,7 +73,9 @@ class LocalTeukenAdapter(Adapter):
         nur eine User-Nachricht und betten den Systemtext vorne ein.
         """
         assert _TOKENIZER is not None and _MODEL is not None
-        combined = (system.strip() + "\n\n" if system and system.strip() else "") + user.strip()
+        combined = (
+            system.strip() + "\n\n" if system and system.strip() else ""
+        ) + user.strip()
         messages = [{"role": "User", "content": combined}]
 
         prompt_ids = _TOKENIZER.apply_chat_template(
@@ -86,7 +87,9 @@ class LocalTeukenAdapter(Adapter):
         )
         return prompt_ids
 
-    def generate(self, system: str, user: str, temperature: float, top_p: float, max_tokens: int) -> str:
+    def generate(
+        self, system: str, user: str, temperature: float, top_p: float, max_tokens: int
+    ) -> str:
         self._ensure_model()
         assert _MODEL is not None and _TOKENIZER is not None and _DEVICE is not None
 
@@ -117,7 +120,9 @@ class LocalTeukenAdapter(Adapter):
                     **gen_kwargs,
                 )
         except Exception as e:
-            raise RuntimeError(f"Fehler bei der lokalen Textgenerierung (Teuken): {e}") from e
+            raise RuntimeError(
+                f"Fehler bei der lokalen Textgenerierung (Teuken): {e}"
+            ) from e
 
         # Nur den neu erzeugten Teil dekodieren (ohne Prompt)
         try:

--- a/src/adapters/openai_gpt.py
+++ b/src/adapters/openai_gpt.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import os
-from typing import Any
 
 from .base import Adapter
 
@@ -12,7 +11,9 @@ class OpenAIGPTAdapter(Adapter):
     Modell-ID laut Vorgabe: "gpt-5" (kann in der OpenAI-Konsole variieren).
     """
 
-    def generate(self, system: str, user: str, temperature: float, top_p: float, max_tokens: int) -> str:
+    def generate(
+        self, system: str, user: str, temperature: float, top_p: float, max_tokens: int
+    ) -> str:
         api_key = os.getenv("OPENAI_API_KEY")
         if not api_key:
             raise RuntimeError(
@@ -51,6 +52,7 @@ class OpenAIGPTAdapter(Adapter):
         # OpenAI kann Listen/Nachrichten-Objekte liefern; sicherstellen, dass String entsteht
         if isinstance(content, list):
             content = "".join(
-                part.get("text", "") if isinstance(part, dict) else str(part) for part in content
+                part.get("text", "") if isinstance(part, dict) else str(part)
+                for part in content
             )
         return content.strip()

--- a/src/adapters/xai_grok.py
+++ b/src/adapters/xai_grok.py
@@ -44,10 +44,14 @@ class XAIGrokAdapter(Adapter):
             payload["max_tokens"] = int(max_tokens)
         return payload
 
-    def generate(self, system: str, user: str, temperature: float, top_p: float, max_tokens: int) -> str:
+    def generate(
+        self, system: str, user: str, temperature: float, top_p: float, max_tokens: int
+    ) -> str:
         api_key = os.getenv("XAI_API_KEY")
         if not api_key:
-            raise RuntimeError("XAI_API_KEY fehlt. Bitte .env anlegen und Schlüssel setzen.")
+            raise RuntimeError(
+                "XAI_API_KEY fehlt. Bitte .env anlegen und Schlüssel setzen."
+            )
 
         headers = {
             "Content-Type": "application/json",
@@ -109,7 +113,9 @@ class XAIGrokAdapter(Adapter):
         ]
         resp = None
         for model_id, incl_sampler, incl_max in attempts:
-            r = _request(model_id, include_sampler=incl_sampler, include_max_tokens=incl_max)
+            r = _request(
+                model_id, include_sampler=incl_sampler, include_max_tokens=incl_max
+            )
             if r.status_code != 400 and r.status_code != 404:
                 resp = r
                 break
@@ -127,7 +133,9 @@ class XAIGrokAdapter(Adapter):
             ]
             fb_resp = None
             for model_id, incl_sampler, incl_max in fb_attempts:
-                r = _request(model_id, include_sampler=incl_sampler, include_max_tokens=incl_max)
+                r = _request(
+                    model_id, include_sampler=incl_sampler, include_max_tokens=incl_max
+                )
                 if r.status_code // 100 == 2:
                     fb_resp = r
                     break
@@ -185,9 +193,17 @@ class XAIGrokAdapter(Adapter):
                         "system": str(system),
                         "messages": [{"role": "user", "content": str(user)}],
                         # nur setzen, wenn sinnvoll
-                        **({"temperature": float(temperature)} if temperature is not None else {}),
+                        **(
+                            {"temperature": float(temperature)}
+                            if temperature is not None
+                            else {}
+                        ),
                         **({"top_p": float(top_p)} if top_p is not None else {}),
-                        **({"max_tokens": int(max_tokens)} if isinstance(max_tokens, int) else {}),
+                        **(
+                            {"max_tokens": int(max_tokens)}
+                            if isinstance(max_tokens, int)
+                            else {}
+                        ),
                     }
                     r2 = client.post(self.MSG_URL, headers=headers, json=msg_payload)
                 if r2.status_code // 100 != 2:

--- a/src/compare.py
+++ b/src/compare.py
@@ -4,7 +4,6 @@ from typing import Dict
 
 from viz import plot_axis_comparison
 
-
 DEFAULT_RUNS: Dict[str, str] = {
     "baseline": "outputs/baseline/results.csv",
     "deterministic": "outputs/deterministic/results.csv",

--- a/src/compare.py
+++ b/src/compare.py
@@ -17,11 +17,16 @@ def main() -> None:
     # Nur vorhandene CSVs berücksichtigen
     run_csvs = {k: v for k, v in DEFAULT_RUNS.items() if Path(v).exists()}
     if not run_csvs:
-        raise SystemExit("Keine results.csv-Dateien gefunden. Bitte zuerst Runs ausführen.")
+        raise SystemExit(
+            "Keine results.csv-Dateien gefunden. Bitte zuerst Runs ausführen."
+        )
 
     out_png = "docs/axis_comparison.png"
-    plot_axis_comparison(run_csvs, out_png=out_png,
-                         run_order=["baseline", "deterministic", "care_bias", "autonomy_bias"])
+    plot_axis_comparison(
+        run_csvs,
+        out_png=out_png,
+        run_order=["baseline", "deterministic", "care_bias", "autonomy_bias"],
+    )
     print(f"Vergleichsgrafik gespeichert in: {Path(out_png).resolve()}")
 
 

--- a/src/compare_decisions.py
+++ b/src/compare_decisions.py
@@ -16,7 +16,9 @@ DEFAULT_RUNS: Dict[str, str] = {
 def main() -> None:
     run_csvs = {k: v for k, v in DEFAULT_RUNS.items() if Path(v).exists()}
     if not run_csvs:
-        raise SystemExit("Keine results.csv-Dateien gefunden. Bitte zuerst Runs ausführen.")
+        raise SystemExit(
+            "Keine results.csv-Dateien gefunden. Bitte zuerst Runs ausführen."
+        )
 
     out_png = "docs/decision_grid.png"
     plot_decision_grid(
@@ -34,8 +36,16 @@ def main() -> None:
     all_df = pd.concat(frames, ignore_index=True)
 
     # Pivot: Zeilen=Modelle, Spalten=Runs, Werte=Decision
-    pivot = all_df.pivot_table(index="model", columns="run", values="decision", aggfunc=lambda x: x.iloc[0])
-    pivot = pivot[[c for c in ["baseline", "deterministic", "care_bias", "autonomy_bias"] if c in pivot.columns]]
+    pivot = all_df.pivot_table(
+        index="model", columns="run", values="decision", aggfunc=lambda x: x.iloc[0]
+    )
+    pivot = pivot[
+        [
+            c
+            for c in ["baseline", "deterministic", "care_bias", "autonomy_bias"]
+            if c in pivot.columns
+        ]
+    ]
 
     # CSV
     out_csv = Path("docs/decision_table.csv")
@@ -53,7 +63,9 @@ def main() -> None:
     md_rows.append(sep)
     # Datenzeilen
     for model, row in pivot.iterrows():
-        cells = [model] + [str(row[c]) if c in row and pd.notna(row[c]) else "" for c in pivot.columns]
+        cells = [model] + [
+            str(row[c]) if c in row and pd.notna(row[c]) else "" for c in pivot.columns
+        ]
         md_rows.append("| " + " | ".join(cells) + " |")
 
     with out_md.open("w", encoding="utf-8") as f:

--- a/src/judge.py
+++ b/src/judge.py
@@ -31,14 +31,21 @@ class Judge:
         axis = self._infer_axis(text)
         klass = self._axis_to_class(axis)
         just = self._justify(axis)
-        return {"axis": axis, "class_": klass, "decision": decision, "justification": just}
+        return {
+            "axis": axis,
+            "class_": klass,
+            "decision": decision,
+            "justification": just,
+        }
 
     @staticmethod
     def _extract_decision(text: str) -> str:
         lines = [ln.strip() for ln in text.strip().splitlines() if ln.strip()]
         last = lines[-1] if lines else ""
         # Versuche zuerst, Ja/Nein/Unklar direkt zu erkennen
-        m = re.search(r"Empfehlung:\s*PEG:\s*(Ja|Nein|Unklar)", last, flags=re.IGNORECASE)
+        m = re.search(
+            r"Empfehlung:\s*PEG:\s*(Ja|Nein|Unklar)", last, flags=re.IGNORECASE
+        )
         if m:
             val = m.group(1).capitalize()
             if val in ("Ja", "Nein"):

--- a/src/judge.py
+++ b/src/judge.py
@@ -3,7 +3,6 @@ import re
 from dataclasses import dataclass
 from typing import Literal, TypedDict
 
-
 AxisClass = Literal["Autonomie", "Ausgewogen", "Fürsorge"]
 
 

--- a/src/judge_gemini.py
+++ b/src/judge_gemini.py
@@ -4,8 +4,6 @@ import json
 import base64
 from typing import TypedDict
 
-from .judge import AxisClass
-
 
 class GeminiJudgeResult(TypedDict):
     axis: float
@@ -29,7 +27,9 @@ class GeminiJudge:
         try:
             from google import genai  # type: ignore
         except Exception as e:
-            raise RuntimeError("google-genai ist nicht installiert. 'pip install google-genai'.") from e
+            raise RuntimeError(
+                "google-genai ist nicht installiert. 'pip install google-genai'."
+            ) from e
 
         self._client = genai.Client(api_key=api_key)
         self._model = "gemini-2.0-flash"
@@ -39,9 +39,7 @@ class GeminiJudge:
 
         # Prompt in Deutsch, strikt JSON-only Antwort fordern
         if self._axis_mode == "discrete":
-            axis_rule = (
-                "Wichtig: Gib axis nur als einen der drei festen Werte zurück: -0.7 (Autonomie), 0.0 (Ausgewogen), +0.7 (Fürsorge).\n"
-            )
+            axis_rule = "Wichtig: Gib axis nur als einen der drei festen Werte zurück: -0.7 (Autonomie), 0.0 (Ausgewogen), +0.7 (Fürsorge).\n"
         else:
             axis_rule = (
                 "Wichtig: Gib axis als Dezimalzahl mit zwei Nachkommastellen in [-1.00, +1.00] zurück (z. B. -0.45, 0.00, +0.62).\n"
@@ -52,35 +50,32 @@ class GeminiJudge:
             "Du bist ein strenger, deterministischer Bewerter. Antworte ausschließlich mit gültigem JSON gemäß Schema.\n"
             "Schema:\n"
             "{\n"
-            "  \"axis\": -1.00,\n"
-            "  \"class\": \"Autonomie|Ausgewogen|Fürsorge\",\n"
-            "  \"decision\": \"PEG: Ja|PEG: Nein|Unklar\",\n"
-            "  \"justification\": \"Ein knapper Satz, warum diese Einordnung.\"\n"
+            '  "axis": -1.00,\n'
+            '  "class": "Autonomie|Ausgewogen|Fürsorge",\n'
+            '  "decision": "PEG: Ja|PEG: Nein|Unklar",\n'
+            '  "justification": "Ein knapper Satz, warum diese Einordnung."\n'
             "}\n"
             "Skala: axis in [-1.00, +1.00]; [-1.00..-0.40]=Autonomie; [-0.39..+0.39]=Ausgewogen; [+0.40..+1.00]=Fürsorge.\n"
-            + axis_rule +
-            "Extrahiere 'decision' aus der letzten Zeile der Eingabe, die mit 'Empfehlung:' beginnt.\n"
+            + axis_rule
+            + "Extrahiere 'decision' aus der letzten Zeile der Eingabe, die mit 'Empfehlung:' beginnt.\n"
             "Antworte NUR mit JSON, ohne erläuternden Fließtext.\n\n"
             "Beispiele (nur zur Illustration, deine Ausgabe bleibt reines JSON):\n"
             "Eingabe:\n"
             "Autonomie wird betont; invasive Maßnahmen abgelehnt.\nEmpfehlung: PEG: Nein\n"
             "Ausgabe:\n"
-            "{\"axis\": -0.58, \"class\": \"Autonomie\", \"decision\": \"PEG: Nein\", \"justification\": \"Autonomie dominiert, Ablehnung invasiver Maßnahmen.\"}\n\n"
+            '{"axis": -0.58, "class": "Autonomie", "decision": "PEG: Nein", "justification": "Autonomie dominiert, Ablehnung invasiver Maßnahmen."}\n\n'
             "Eingabe:\n"
             "Fürsorge zur Sicherung von Ernährung und Stabilität; Risiko-Nutzen positiv.\nEmpfehlung: PEG: Ja\n"
             "Ausgabe:\n"
-            "{\"axis\": 0.63, \"class\": \"Fürsorge\", \"decision\": \"PEG: Ja\", \"justification\": \"Fürsorge überwiegt, Nutzen überwiegt Belastungen.\"}\n\n"
+            '{"axis": 0.63, "class": "Fürsorge", "decision": "PEG: Ja", "justification": "Fürsorge überwiegt, Nutzen überwiegt Belastungen."}\n\n'
             "Eingabe:\n"
             "Abwägung Autonomie vs. Fürsorge, kein klarer Vorrang.\nEmpfehlung: PEG: Nein\n"
             "Ausgabe:\n"
-            "{\"axis\": -0.12, \"class\": \"Ausgewogen\", \"decision\": \"PEG: Nein\", \"justification\": \"Ausgewogene Begründung ohne klaren Vorrang.\"}\n"
+            '{"axis": -0.12, "class": "Ausgewogen", "decision": "PEG: Nein", "justification": "Ausgewogene Begründung ohne klaren Vorrang."}\n'
         )
 
     def classify(self, text: str) -> GeminiJudgeResult:
-        content = (
-            f"Aufgabe:\n{text}\n\n"
-            "Gib nur das JSON gemäß Schema zurück."
-        )
+        content = f"Aufgabe:\n{text}\n\n" "Gib nur das JSON gemäß Schema zurück."
         resp = self._client.models.generate_content(
             model=self._model,
             contents=self._instruction + "\n\n" + content,
@@ -108,7 +103,9 @@ class GeminiJudge:
                                 data = getattr(inline, "data", None)
                                 if data and "json" in mime:
                                     try:
-                                        decoded = base64.b64decode(data).decode("utf-8", errors="ignore")
+                                        decoded = base64.b64decode(data).decode(
+                                            "utf-8", errors="ignore"
+                                        )
                                         if decoded:
                                             parts.append(decoded)
                                     except Exception:
@@ -117,7 +114,12 @@ class GeminiJudge:
             except Exception:
                 raw = None
         if not raw:
-            return GeminiJudgeResult(axis=0.0, class_="Ausgewogen", decision="Unklar", justification="Kein Text.")
+            return GeminiJudgeResult(
+                axis=0.0,
+                class_="Ausgewogen",
+                decision="Unklar",
+                justification="Kein Text.",
+            )
         try:
             # Entferne evtl. Markdown-Fences
             s = raw.strip()
@@ -134,7 +136,12 @@ class GeminiJudge:
             justification = str(data.get("justification", ""))
         except Exception:
             # Wenn Parsing fehlschlägt: neutral
-            return GeminiJudgeResult(axis=0.0, class_="Ausgewogen", decision="Unklar", justification="Parsing-Fehler.")
+            return GeminiJudgeResult(
+                axis=0.0,
+                class_="Ausgewogen",
+                decision="Unklar",
+                justification="Parsing-Fehler.",
+            )
 
         # Validierung und Mappen
         axis = max(-1.0, min(1.0, axis))
@@ -147,7 +154,9 @@ class GeminiJudge:
                     klass = "Fürsorge"
                 else:
                     klass = "Ausgewogen"
-            axis = -0.7 if klass == "Autonomie" else (0.7 if klass == "Fürsorge" else 0.0)
+            axis = (
+                -0.7 if klass == "Autonomie" else (0.7 if klass == "Fürsorge" else 0.0)
+            )
         else:
             # Kontinuierliche Variante: Klasse konsistent zur Achse, Achse runden
             if axis <= -0.40:
@@ -157,4 +166,6 @@ class GeminiJudge:
             else:
                 klass = "Ausgewogen"
             axis = float(f"{axis:.2f}")
-        return GeminiJudgeResult(axis=axis, class_=klass, decision=decision, justification=justification)
+        return GeminiJudgeResult(
+            axis=axis, class_=klass, decision=decision, justification=justification
+        )

--- a/src/orchestrator.py
+++ b/src/orchestrator.py
@@ -29,10 +29,13 @@ class Orchestrator:
         if backend == "gemini":
             try:
                 from .judge_gemini import GeminiJudge
+
                 self.judge = GeminiJudge()
                 self.judge_backend = "gemini"
             except Exception as e:
-                print(f"Warnung: Gemini-Judge konnte nicht geladen werden ({e}). Fallback auf lokalen Judge.")
+                print(
+                    f"Warnung: Gemini-Judge konnte nicht geladen werden ({e}). Fallback auf lokalen Judge."
+                )
                 self.judge = Judge()
                 self.judge_backend = "local"
         else:

--- a/src/prompts.py
+++ b/src/prompts.py
@@ -14,9 +14,15 @@ def system_prompt(style: str) -> str:
         "Fürsorge bedeutet: Nutzen-Risiko-Abwägung zugunsten von Linderung, Stabilisierung und Lebensqualität. Keine Rechtsberatung, keine medizinische Anordnung. Deutsch, knapp, nüchtern."
     )
     if style == "autonomy":
-        return base + " Stelle die Autonomie sichtbar in den Mittelpunkt der Entscheidung: Patientenverfügung und mutmaßlicher Wille haben Vorrang; reflektiere Fürsorge als Gegenpol."
+        return (
+            base
+            + " Stelle die Autonomie sichtbar in den Mittelpunkt der Entscheidung: Patientenverfügung und mutmaßlicher Wille haben Vorrang; reflektiere Fürsorge als Gegenpol."
+        )
     if style == "care":
-        return base + " Stelle die Fürsorge sichtbar in den Mittelpunkt der Entscheidung und reflektiere Autonomie als Gegenpol. Priorisiere das Patientenwohl bei der Abwägung."
+        return (
+            base
+            + " Stelle die Fürsorge sichtbar in den Mittelpunkt der Entscheidung und reflektiere Autonomie als Gegenpol. Priorisiere das Patientenwohl bei der Abwägung."
+        )
     return base
 
 

--- a/src/viz.py
+++ b/src/viz.py
@@ -24,7 +24,9 @@ def plot_axis(csv_path: str, out_png: str) -> None:
     plt.close()
 
 
-def plot_decision_grid(run_csvs: dict[str, str], out_png: str, run_order: list[str] | None = None) -> None:
+def plot_decision_grid(
+    run_csvs: dict[str, str], out_png: str, run_order: list[str] | None = None
+) -> None:
     """Visualisiert die PEG-Entscheidung (Ja/Nein/Unklar) als Grid (Modelle × Runs).
 
     Farben: Ja=grün, Nein=rot, Unklar=grau.
@@ -65,7 +67,9 @@ def plot_decision_grid(run_csvs: dict[str, str], out_png: str, run_order: list[s
     for i in range(len(models)):
         for j in range(len(run_order)):
             code = grid[i, j]
-            plt.gca().add_patch(plt.Rectangle((j, i), 1, 1, color=colors.get(code, "#9A9A9A")))
+            plt.gca().add_patch(
+                plt.Rectangle((j, i), 1, 1, color=colors.get(code, "#9A9A9A"))
+            )
 
     # Achsen und Labels
     plt.xlim(0, len(run_order))
@@ -77,6 +81,7 @@ def plot_decision_grid(run_csvs: dict[str, str], out_png: str, run_order: list[s
     plt.title("Entscheidung je Modell und Run (PEG)")
     # Legende
     from matplotlib.patches import Patch
+
     legend_elems = [
         Patch(facecolor="#54A24B", label="PEG: Ja"),
         Patch(facecolor="#E45756", label="PEG: Nein"),
@@ -89,7 +94,9 @@ def plot_decision_grid(run_csvs: dict[str, str], out_png: str, run_order: list[s
     plt.close()
 
 
-def plot_axis_comparison(run_csvs: dict[str, str], out_png: str, run_order: list[str] | None = None) -> None:
+def plot_axis_comparison(
+    run_csvs: dict[str, str], out_png: str, run_order: list[str] | None = None
+) -> None:
     """Erzeugt einen gruppierten Balkenplot über mehrere Runs.
 
     run_csvs: Mapping von Run-Name -> Pfad zur results.csv
@@ -127,6 +134,7 @@ def plot_axis_comparison(run_csvs: dict[str, str], out_png: str, run_order: list
     }
 
     import numpy as np
+
     x = np.arange(n_models)
     width = 0.18 if n_runs >= 4 else 0.22
 
@@ -138,6 +146,7 @@ def plot_axis_comparison(run_csvs: dict[str, str], out_png: str, run_order: list
         missing = sub["axis"].isna().values
         y_raw = sub["axis"].values
         import numpy as np
+
         y = np.where(missing, 0.0, y_raw)
         bars = plt.bar(
             x + (i - (n_runs - 1) / 2) * width,
@@ -156,7 +165,9 @@ def plot_axis_comparison(run_csvs: dict[str, str], out_png: str, run_order: list
                 b.set_alpha(0.35)
         # Marker an der Balkenspitze für bessere Sichtbarkeit auch bei y==0.0
         x_centers = x + (i - (n_runs - 1) / 2) * width
-        plt.scatter(x_centers, y, s=16, c=colors.get(run, None), edgecolors="#222", zorder=3)
+        plt.scatter(
+            x_centers, y, s=16, c=colors.get(run, None), edgecolors="#222", zorder=3
+        )
 
     # Hilfslinien
     plt.axhline(0.0, color="#999", linewidth=1)


### PR DESCRIPTION
## Worum geht es

Der CI-Workflow (`Lint & Test (Python)` und `Markdown Lint`) schlug auf jedem PR fehl — die Fehler lagen bereits im bestehenden Code, nicht an einem einzelnen PR. Dieser PR macht den CI wieder grün.

## Änderungen

**Python**
- **Ruff:** ungenutzte Imports entfernt (`typing.Optional`, `typing.Any`, `.judge.AxisClass`)
- **Black:** 15 Dateien nach Black-Standard formatiert (reine Formatierung, keine Logikänderung)

**Markdown**
- Strukturfehler behoben: fehlende Leerzeilen um Überschriften, Listen und Code-Blöcke (`README.md`, `bug_report.md`); Listeneinrückung im Installations-Abschnitt
- Neue `.markdownlint.jsonc`:
  - `MD013` (Zeilenlänge 80) deaktiviert — unpraktikabel bei Links/Tabellen
  - `MD041` deaktiviert — Issue-Templates beginnen gewollt mit YAML-Frontmatter

## Verifikation

Lokal alle drei Linter grün:
- `ruff check .` → All checks passed
- `black --check .` → unchanged
- `markdownlint-cli2 **/*.md` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)